### PR TITLE
Narrowing abstract

### DIFF
--- a/cls/aastex61.cls
+++ b/cls/aastex61.cls
@@ -841,6 +841,7 @@ Typeset using \LaTeX\ {\bf modern} style in AASTeX61}
     \frontmatter@abstractheading
     \frontmatter@abstractfont
 %    \let\footnote\mini@note
+    \everypar{\rightskip=0.5in\leftskip=\rightskip}\par
     \expandafter\everypar\expandafter{\the\everypar\addcontents@abstract\everypar{}}%
 \ifnumlines\let\go\linenumbers\else\let\go\relax\fi\go
 }{%


### PR DESCRIPTION
This PR narrows the abstract by 0.5in and closes #52. It re-implements the code from v6.0 as suggested by @pcubillos, but in a slightly different location (in the `abstract` environment rather than `abstractheading`).