### PR TITLE
Fixed comma in authorlist to appear after the affiliation

### DIFF
--- a/cls/aastex62.cls
+++ b/cls/aastex62.cls
@@ -6255,7 +6255,7 @@ needed. It will not do anything.^^J Please use
 \ifnum\AuthorCollaborationLimit=1
 \let\@listand\relax
 \fi
-  \ignorespaces\leavevmode\hbox{#1\unskip\@listcomma}% nice, keeps name from breaking across lines
+  \ignorespaces\leavevmode\hbox{#1\unskip}% nice, keeps name from breaking across lines
 \fi
   \begingroup
 \ifnum\countauthors>\AuthorCollaborationLimit\else
@@ -6270,7 +6270,7 @@ needed. It will not do anything.^^J Please use
 {\ifnum\countauthors>\AuthorCollaborationLimit\endgroup{}{}%% <<< bug fix, added \endgroup{}{}
 \else
 \endgroup{\comma@space}{}\frontmatter@footnote{#2}\fi}%
-\ifnum\countauthors>\AuthorCollaborationLimit\else  \space
+\ifnum\countauthors>\AuthorCollaborationLimit\else\@listcomma  \space
 \@listand\fi 
 }%
 


### PR DESCRIPTION
For author lists with more than two entries, the affiliation superindices was appearing after the comma:

![screen shot 2018-03-30 at 1 51 38 pm](https://user-images.githubusercontent.com/2119263/38136876-a10469c0-3421-11e8-8402-8f448c6a8398.png)

This PR fixes that:

![screen shot 2018-03-30 at 1 47 10 pm](https://user-images.githubusercontent.com/2119263/38136758-e6af6764-3420-11e8-8391-8bc411423870.png)
