### PR TITLE
Add DOIs to proceedings and collections

### DIFF
--- a/bst/aasjournal.bst
+++ b/bst/aasjournal.bst
@@ -1285,6 +1285,7 @@ FUNCTION {incollection}
 %    }
 %  if$
   format.pages "pages" output.check
+  format.pid output
   format.url output
   fin.entry
 }
@@ -1313,6 +1314,7 @@ FUNCTION {inproceedings}
 %    }
 %  if$
   format.pages output
+  format.pid output
   format.url output
   fin.entry
 }


### PR DESCRIPTION
SPIE papers come with DOIs and ADS includes them in entries. It seems odd to me that we include DOIs for articles but not for proceedings papers that have them. SPIE papers are notoriously hard to parse since page numbers are usually missing from references.