### PR TITLE
aastex62.cls: fix extra line in \tablebreak

### DIFF
--- a/cls/aastex62.cls
+++ b/cls/aastex62.cls
@@ -6030,7 +6030,7 @@ on page
 {\@currentHref }{\relax }}{#3}\fi }\fi \par \endgroup}}
 
 
-\newcommand\tablebreak{\\[-11pt]\noalign{\break}\\ }
+\newcommand\tablebreak{\\[-11pt]\noalign{\break} }
 
 %% As suggested by Greg Schwarz, August Meunch, Feb 11
 


### PR DESCRIPTION
This PR fixes the bug in `\tablebreak` described in #76.