### PR TITLE
Class typo?

### DIFF
--- a/docs/aassymbols.tex
+++ b/docs/aassymbols.tex
@@ -1,4 +1,4 @@
-\documentclass[twocolumn]{aastex3}
+\documentclass[twocolumn]{aastex63}
 
 \newcommand\aastex{AAS\TeX}%
 

--- a/other/natbib.tex
+++ b/other/natbib.tex
@@ -1,4 +1,4 @@
-\documentclass[onecolumn]{aastex3}
+\documentclass[onecolumn]{aastex63}
 
 \newcommand\aastex{AAS\TeX}%
 


### PR DESCRIPTION
Unless I've missed something, aastex3 appears to be a typo for aastex63? Let me know if I'm off base here.