### PR TITLE
Bibstyle does not dash repeated authors if entries are `inproceedings`

### DIFF
--- a/bst/aasjournal.bst
+++ b/bst/aasjournal.bst
@@ -1308,6 +1308,7 @@ FUNCTION {inproceedings}
 { output.bibitem
   format.authors "author" output.check
   author format.key output            % added
+  name.or.dash
   format.date "year" output.check
   date.block
   bbl.in " " * booktitle format.full.book.spec * output


### PR DESCRIPTION
I found while using the derivative `apj.bst` used by the Publications of the Astronomical Society of Australia that the style will omit the authors in bibliography entries where the authors are the same as the previous entry, instead replacing the author list with an em-dash. However, this is not run if the subsequent entries are of type `inproceedings`.